### PR TITLE
Add recover method to JobOperator

### DIFF
--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/JobOperator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/JobOperator.java
@@ -39,6 +39,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Dave Syer
  * @author Mahmoud Ben Hassine
+ * @author Yejeong Ham
  * @since 2.0
  */
 @SuppressWarnings("removal")
@@ -247,6 +248,18 @@ public interface JobOperator extends JobLauncher {
 	 * should be stopped first)
 	 */
 	JobExecution abandon(JobExecution jobExecution) throws JobExecutionAlreadyRunningException;
+
+	/**
+	 * Marks the given {@link JobExecution} as {@code FAILED} when it is stuck in a
+	 * {@code STARTED} state due to an abrupt shutdown or failure, in order to make it
+	 * restartable. This operation makes a previously non-restartable execution eligible
+	 * for restart by updating its execution context with the flag {@code recovered=true}.
+	 * @param jobExecution the {@link JobExecution} to recover
+	 * @return the {@link JobExecution} after it has been marked as recovered
+	 * @throws UnexpectedJobExecutionException if the job execution is already complete or
+	 * abandoned
+	 */
+	JobExecution recover(JobExecution jobExecution);
 
 	/**
 	 * List the {@link JobExecution JobExecutions} associated with a particular

--- a/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/TaskExecutorJobOperator.java
+++ b/spring-batch-core/src/main/java/org/springframework/batch/core/launch/support/TaskExecutorJobOperator.java
@@ -51,6 +51,7 @@ import org.springframework.util.Assert;
  * @author Lucas Ward
  * @author Will Schipp
  * @author Mahmoud Ben Hassine
+ * @author Yejeong Ham
  * @since 6.0
  */
 @SuppressWarnings("removal")
@@ -117,6 +118,12 @@ public class TaskExecutorJobOperator extends SimpleJobOperator {
 	public JobExecution abandon(JobExecution jobExecution) throws JobExecutionAlreadyRunningException {
 		Assert.notNull(jobExecution, "JobExecution must not be null");
 		return super.abandon(jobExecution);
+	}
+
+	@Override
+	public JobExecution recover(JobExecution jobExecution) {
+		Assert.notNull(jobExecution, "JobExecution must not be null");
+		return super.recover(jobExecution);
 	}
 
 }

--- a/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/CommandLineJobOperatorTests.java
+++ b/spring-batch-core/src/test/java/org/springframework/batch/core/launch/support/CommandLineJobOperatorTests.java
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.mock;
  * Tests for {@link CommandLineJobOperator}.
  *
  * @author Mahmoud Ben Hassine
+ * @author Yejeong Ham
  */
 class CommandLineJobOperatorTests {
 
@@ -131,6 +132,20 @@ class CommandLineJobOperatorTests {
 
 		// then
 		Mockito.verify(jobOperator).abandon(jobExecution);
+	}
+
+	@Test
+	void recover() {
+		// given
+		long jobExecutionId = 1;
+		JobExecution jobExecution = mock();
+
+		// when
+		Mockito.when(jobRepository.getJobExecution(jobExecutionId)).thenReturn(jobExecution);
+		this.commandLineJobOperator.recover(jobExecutionId);
+
+		// then
+		Mockito.verify(jobOperator).recover(jobExecution);
 	}
 
 }


### PR DESCRIPTION
## Description

This PR introduces a new `recover` method to the `JobOperator` interface and its implementations. 
This method allows to recover a failed job execution based on its ID. This is useful for restarting a failed job from the point where it left off.

This PR also adds unit tests for the new `recover` method in `JobOperator`.

## Related Issue

Resolves #4876

## Changes

- Add `recover` method to `JobOperator` interface.
- Implement the `recover` method in `SimpleJobOperator`.
- Add unit tests for `JobOperator.recover` in `TaskExecutorJobOperatorTests`.
- Add `recover` method to `CommandLineJobOperator`
- Add unit tests for `CommandLineJobOperator.recover` in `CommandLineJobOperatorTests`.

## Additional Notes
At SimpleJobOperator.java line 403, when a job execution is already recovered,
I currently throw an existing exception class.
I’m considering whether it would be better to:

Define a new exception class (e.g., AlreadyRecoveredException) — similar to how abandon throws an exception, or
Skip throwing an exception and instead log the event while returning the JobExecution.

For now, I’ve chosen to throw an exception for consistency with abandon